### PR TITLE
[FIX] MMO_Overhead fix

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -12,5 +12,5 @@ var $plugins =
 {"name":"MMO_Core_Bank","status":true,"description":"MMORPG Maker MV - Core Handling Bank","parameters":{}},
 {"name":"MMO_ChatBox","status":true,"description":"MMORPG Maker MV - ChatBox","parameters":{"chatPosition":"TOP LEFT"}},
 {"name":"MMO_LoginForm","status":true,"description":"MMORPG Maker MV - Login Form","parameters":{"allowAccountCreation":"Yes"}},
-{"name":"MMO_Overhead","status":false,"description":"Add name over actors name","parameters":{}}
+{"name":"MMO_Overhead","status":true,"description":"Add name over actors name","parameters":{}}
 ];

--- a/js/plugins/MMO_Overhead.js
+++ b/js/plugins/MMO_Overhead.js
@@ -58,21 +58,29 @@ MMO_Overhead.forceRefresh = function() {
 MMO_Overhead.Windows.prototype = Object.create(Window_Base.prototype);
 MMO_Overhead.Windows.prototype.constructor = MMO_Overhead.Windows;
 
+MMO_Overhead.standardPadding = function() {
+  return 18;
+};
+
+MMO_Overhead.textPadding = function() {
+  return 6;
+};
+
 MMO_Overhead.Windows.prototype.initialize = function() {
-    // this._bufferX = 0;
-    // this._bufferY = 36;
-    // this._fontSize = 14;
-    // this._alwaysShow = false;
-    // var width = 136;
-    // var height = this.windowHeight();
-    // this._range = 5;
-    // Window_Base.prototype.initialize.call(this, 0, 0, width, height);
-    // this.opacity = 0;
-    // this.contentsOpacity = 0;
-    // this._character = null;
-    // this._page = 0;
-    // this._text = '';
-    // this._initialText = '';
+    this._bufferX = 0;
+    this._bufferY = 36;
+    this._fontSize = 14;
+    this._alwaysShow = false;
+    var width = 136;
+    var height = this.windowHeight();
+    this._range = 5;
+    Window_Base.prototype.initialize.call(this, {x:0, y:0, width, height});
+    this.opacity = 0;
+    this.contentsOpacity = 0;
+    this._character = null;
+    this._page = 0;
+    this._text = '';
+    this._initialText = '';
 };
 
 MMO_Overhead.Windows.prototype.standardFontSize = function() {
@@ -82,7 +90,7 @@ MMO_Overhead.Windows.prototype.standardFontSize = function() {
 
 MMO_Overhead.Windows.prototype.windowHeight = function() {
     var height = this.fittingHeight(1)
-    height = Math.max(height, 48 + 8 * 2);
+    height = Math.max(height, 48 + MMO_Overhead.standardPadding() * 2);
     return height;
 };
 
@@ -180,15 +188,15 @@ MMO_Overhead.Windows.prototype.setText = function(text) {
 MMO_Overhead.Windows.prototype.refresh = function() {
     this.contents.clear();
     var txWidth = this.textWidthEx(this._text);
-    txWidth += this.textPadding() * 2;
+    txWidth += MMO_Overhead.textPadding() * 2;
     var width = txWidth;
     this.width = Math.max(width, 136);
-    this.width += 8 * 2;
+    this.width += MMO_Overhead.standardPadding() * 2;
     this.height = this.windowHeight();
     this.createContents();
     var wx = (this.contents.width - txWidth) / 2;
     var wy = 0;
-    this.drawTextEx(this._text, wx + this.textPadding(), wy);
+    this.drawTextEx(this._text, wx + MMO_Overhead.textPadding(), wy);
 };
 
 MMO_Overhead.Windows.prototype.forceRefresh = function() {

--- a/js/plugins/MMO_Overhead.js
+++ b/js/plugins/MMO_Overhead.js
@@ -135,38 +135,20 @@ MMO_Overhead.Windows.prototype.gatherDisplayData = function() {
 };
 
 MMO_Overhead.Windows.prototype.extractNotedata = function(comment) {
-  if (comment === '') return;
-  var tag0 = /<(?:PLAYER):[ ](.*)>/i;
-  var tag1 = /<(?:NAME):[ ](.*)>/i;
-  var tag2 = /<(?:IS QUEST)>/i;
-  var tag3 = /<(?:IS ENEMY)>/i;
-  var tag4 = /<(?:IS EVIL)>/i;
-  var tag5 = /<(?:IS FRIEND)>/i;
-  var tag6 = /<(?:IS INFO)>/i;
-  var tag7 = /<(?:SIDE QUEST)>/i;
-  var tag8 = /<(?:IS IMPORTANT)>/i;
-  var notedata = comment.split(/[\r\n]+/);
-  var text = '';
-  for (var i = 0; i < notedata.length; ++i) {
-    var line = notedata[i];
-    var isPlayer = line.match(tag0);
-    if (line.match(tag1) || isPlayer) {
-      text = String(RegExp.$1);
-    } else if (line.match(tag2)) {
-      text = `\\C[20]<Scénario>\n` + text;
-    } else if (line.match(tag3)) {
-      text = "\\C[18]" + text;
-    } else if (line.match(tag4)) {
-      text = "\\C[20]" + text;
-    } else if (line.match(tag5)) {
-      text = "\\C[28]" + text;
-    } else if (line.match(tag6)) {
-      text = "\\C[23]" + text;
-    } else if (line.match(tag7)) {
-      text = `\\C[17]<Quête>\n` + text;
-    } else if (line.match(tag8)) {
-      text = '\\C[6]' + text;
-    }
+  if (comment === "") {
+      return;
+  }
+  const tag1 = /<(?:NAME):[ ](.*)>/i;
+  const tag2 = /<(?:IS QUEST)>/i;
+  const notedata = comment.split(/[\r\n]+/);
+  let text = "";
+  for (let i = 0; i < notedata.length; ++i) {
+      const line = notedata[i];
+      if (line.match(tag1)) {
+          text = String(RegExp.$1);
+      } else if (line.match(tag2)) {
+          text = "\\C[17]" + text;
+      }
   }
   this.setText(text);
   this._initialText = text;


### PR DESCRIPTION
1. Passed a proper Rect object as parameter on `Window_Base.prototype.initialize.call` => specify `x`and `y` parameters in an explicit object, which also contains `height` and `width` that were already defined. 
2. Added `standardPadding` & `textPadding` as intern function in order to copy calls that were implemented in the original Overhead code
3. Set the plugin to `true` in plugins list (`plugins.js`)

+ Reset the Overhead color tags to default in order to serve the exact same configuration as in MV. 